### PR TITLE
feat: Create screen annotation application with core features

### DIFF
--- a/ScreenAnnotation/App.xaml
+++ b/ScreenAnnotation/App.xaml
@@ -1,0 +1,9 @@
+<Application x:Class="ScreenAnnotation.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:ScreenAnnotation"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+
+    </Application.Resources>
+</Application>

--- a/ScreenAnnotation/App.xaml.cs
+++ b/ScreenAnnotation/App.xaml.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Data;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace ScreenAnnotation
+{
+    /// <summary>
+    /// Interaction logic for App.xaml
+    /// </summary>
+    public partial class App : Application
+    {
+    }
+}

--- a/ScreenAnnotation/HotkeyHelper.cs
+++ b/ScreenAnnotation/HotkeyHelper.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Windows;
+
+namespace ScreenAnnotation
+{
+    public static class HotkeyHelper
+    {
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, uint vk);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern bool UnregisterHotKey(IntPtr hWnd, int id);
+
+        public static class Modifiers
+        {
+            public const uint None = 0;
+            public const uint Alt = 1;
+            public const uint Ctrl = 2;
+            public const uint Shift = 4;
+            public const uint WinKey = 8;
+        }
+
+        public static class Keys
+        {
+            public const uint A = 0x41;
+            // Add other virtual key codes here if needed
+        }
+    }
+}

--- a/ScreenAnnotation/MainWindow.xaml
+++ b/ScreenAnnotation/MainWindow.xaml
@@ -1,0 +1,29 @@
+<Window x:Class="ScreenAnnotation.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:ScreenAnnotation"
+        mc:Ignorable="d"
+        Title="Screen Annotation"
+        WindowStyle="None"
+        ResizeMode="NoResize"
+        AllowsTransparency="True"
+        Background="Transparent"
+        Topmost="True"
+        WindowState="Maximized">
+    <Grid>
+        <InkCanvas x:Name="inkCanvas" Background="Transparent" />
+        <local:Toolbar x:Name="toolbar" VerticalAlignment="Top" HorizontalAlignment="Center" Margin="20"
+                       PenButtonClick="PenButton_Click"
+                       HighlighterButtonClick="HighlighterButton_Click"
+                       EraserButtonClick="EraserButton_Click"
+                       ColorButtonClick="ColorButton_Click"
+                       ThicknessChanged="ThicknessSlider_ValueChanged"
+                       UndoButtonClick="UndoButton_Click"
+                       RedoButtonClick="RedoButton_Click"
+                       ClearButtonClick="ClearButton_Click"
+                       ScreenshotButtonClick="ScreenshotButton_Click"
+                       ExitButtonClick="ExitButton_Click"/>
+    </Grid>
+</Window>

--- a/ScreenAnnotation/MainWindow.xaml.cs
+++ b/ScreenAnnotation/MainWindow.xaml.cs
@@ -1,0 +1,240 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Ink;
+using System.Windows.Input;
+using System.Windows.Interop;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using Microsoft.Win32;
+// Note: To use System.Drawing and System.Windows.Forms, you may need to add a reference.
+// For .NET 6, add the System.Drawing.Common and System.Windows.Forms NuGet packages.
+using System.Drawing;
+using SDImaging = System.Drawing.Imaging; // Alias to avoid conflict
+using SWForms = System.Windows.Forms;     // Alias for clarity
+
+namespace ScreenAnnotation
+{
+    public partial class MainWindow : Window
+    {
+        private HwndSource _source;
+        private const int HOTKEY_ID = 9000;
+
+        public MainWindow()
+        {
+            InitializeComponent();
+            // Set initial drawing attributes
+            inkCanvas.DefaultDrawingAttributes.Color = Colors.Red;
+            inkCanvas.DefaultDrawingAttributes.Width = 5;
+            inkCanvas.DefaultDrawingAttributes.Height = 5;
+            inkCanvas.EditingMode = InkCanvasEditingMode.Ink;
+        }
+
+        protected override void OnSourceInitialized(EventArgs e)
+        {
+            base.OnSourceInitialized(e);
+            var helper = new WindowInteropHelper(this);
+            _source = HwndSource.FromHwnd(helper.Handle);
+            _source.AddHook(HwndHook);
+            RegisterHotKey();
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            _source.RemoveHook(HwndHook);
+            _source = null;
+            UnregisterHotKey();
+            base.OnClosed(e);
+        }
+
+        private void RegisterHotKey()
+        {
+            var helper = new WindowInteropHelper(this);
+            if (!HotkeyHelper.RegisterHotKey(helper.Handle, HOTKEY_ID, HotkeyHelper.Modifiers.Ctrl | HotkeyHelper.Modifiers.Alt, HotkeyHelper.Keys.A))
+            {
+                MessageBox.Show("Failed to register hotkey. It might be in use by another application.", "Hotkey Error");
+            }
+        }
+
+        private void UnregisterHotKey()
+        {
+            var helper = new WindowInteropHelper(this);
+            HotkeyHelper.UnregisterHotKey(helper.Handle, HOTKEY_ID);
+        }
+
+        private IntPtr HwndHook(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+        {
+            const int WM_HOTKEY = 0x0312;
+            if (msg == WM_HOTKEY && wParam.ToInt32() == HOTKEY_ID)
+            {
+                ToggleVisibility();
+                handled = true;
+            }
+            return IntPtr.Zero;
+        }
+
+        private void ToggleVisibility()
+        {
+            if (this.IsVisible)
+            {
+                this.Hide();
+            }
+            else
+            {
+                // Get the screen where the mouse is.
+                var mousePosition = SWForms.Control.MousePosition;
+                var screen = SWForms.Screen.FromPoint(mousePosition);
+
+                // Move the window to the correct screen before showing
+                this.WindowState = WindowState.Normal;
+                this.Left = screen.WorkingArea.Left;
+                this.Top = screen.WorkingArea.Top;
+
+                this.Show();
+                this.WindowState = WindowState.Maximized;
+                this.Activate();
+            }
+        }
+
+        private void PenButton_Click(object sender, RoutedEventArgs e)
+        {
+            inkCanvas.EditingMode = InkCanvasEditingMode.Ink;
+            var attr = inkCanvas.DefaultDrawingAttributes;
+            attr.IsHighlighter = false;
+            var color = attr.Color;
+            attr.Color = Color.FromArgb(255, color.R, color.G, color.B);
+        }
+
+        private void HighlighterButton_Click(object sender, RoutedEventArgs e)
+        {
+            inkCanvas.EditingMode = InkCanvasEditingMode.Ink;
+            var attr = inkCanvas.DefaultDrawingAttributes;
+            attr.IsHighlighter = true;
+            var color = attr.Color;
+            attr.Color = Color.FromArgb(128, color.R, color.G, color.B);
+        }
+
+        private void EraserButton_Click(object sender, RoutedEventArgs e)
+        {
+            inkCanvas.EditingMode = InkCanvasEditingMode.EraseByStroke;
+        }
+
+        private void ColorButton_Click(object sender, RoutedEventArgs e)
+        {
+            var button = sender as Button;
+            if (button != null && button.Background is SolidColorBrush brush)
+            {
+                var newColor = brush.Color;
+                var attr = inkCanvas.DefaultDrawingAttributes;
+                attr.Color = newColor;
+
+                if (attr.IsHighlighter)
+                {
+                    attr.Color = Color.FromArgb(128, newColor.R, newColor.G, newColor.B);
+                }
+                else
+                {
+                    attr.Color = Color.FromArgb(255, newColor.R, newColor.G, newColor.B);
+                }
+            }
+        }
+
+        private void ThicknessSlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            if (inkCanvas != null)
+            {
+                var attr = inkCanvas.DefaultDrawingAttributes;
+                attr.Width = e.NewValue;
+                attr.Height = e.NewValue;
+            }
+        }
+
+        private void UndoButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (inkCanvas.CanUndo)
+            {
+                inkCanvas.Undo();
+            }
+        }
+
+        private void RedoButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (inkCanvas.CanRedo)
+            {
+                inkCanvas.Redo();
+            }
+        }
+
+        private void ClearButton_Click(object sender, RoutedEventArgs e)
+        {
+            inkCanvas.Strokes.Clear();
+        }
+
+        private async void ScreenshotButton_Click(object sender, RoutedEventArgs e)
+        {
+            this.Hide();
+            await Task.Delay(250); // Ensure window is hidden
+
+            try
+            {
+                var helper = new WindowInteropHelper(this);
+                var screen = SWForms.Screen.FromHandle(helper.Handle);
+                var bounds = screen.Bounds;
+
+                using (var screenshot = new Bitmap(bounds.Width, bounds.Height, SDImaging.PixelFormat.Format32bppArgb))
+                {
+                    using (var graphics = Graphics.FromImage(screenshot))
+                    {
+                        graphics.CopyFromScreen(bounds.X, bounds.Y, 0, 0, bounds.Size, CopyPixelOperation.SourceCopy);
+                    }
+
+                    var rtb = new RenderTargetBitmap((int)inkCanvas.ActualWidth, (int)inkCanvas.ActualHeight, 96d, 96d, PixelFormats.Pbgra32);
+                    rtb.Render(inkCanvas);
+
+                    var encoder = new PngBitmapEncoder();
+                    encoder.Frames.Add(BitmapFrame.Create(rtb));
+
+                    using (var stream = new MemoryStream())
+                    {
+                        encoder.Save(stream);
+                        stream.Position = 0;
+                        using (var inkBitmap = new Bitmap(stream))
+                        {
+                            using (var graphics = Graphics.FromImage(screenshot))
+                            {
+                                graphics.DrawImage(inkBitmap, 0, 0);
+                            }
+                        }
+                    }
+
+                    var dialog = new SaveFileDialog
+                    {
+                        FileName = $"Capture_{DateTime.Now:yyyyMMdd_HHmmss}.png",
+                        Filter = "PNG Image|*.png"
+                    };
+
+                    if (dialog.ShowDialog() == true)
+                    {
+                        screenshot.Save(dialog.FileName, SDImaging.ImageFormat.Png);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Could not take screenshot. Error: {ex.Message}", "Error");
+            }
+            finally
+            {
+                this.Show();
+            }
+        }
+
+        private void ExitButton_Click(object sender, RoutedEventArgs e)
+        {
+            Application.Current.Shutdown();
+        }
+    }
+}

--- a/ScreenAnnotation/README.md
+++ b/ScreenAnnotation/README.md
@@ -1,0 +1,71 @@
+# Screen Annotation
+
+A simple and modern desktop screen annotation tool for Windows 10/11, built with C# and WPF. This application allows you to draw directly on your screen, making it perfect for presentations, screen recordings, and online teaching.
+
+## Features
+
+- **Transparent Overlay**: A fully transparent window that sits on top of all other applications, allowing you to draw over anything.
+- **Global Hotkey**: Toggle annotation mode on and off with a global hotkey (**Ctrl+Alt+A**).
+- **Drawing Tools**:
+    - **Pen**: A freehand pen tool for drawing.
+    - **Highlighter**: A semi-transparent highlighter to emphasize content.
+    - **Eraser**: A stroke-based eraser to remove annotations.
+- **Customization**:
+    - **Color Palette**: Choose from a selection of colors.
+    - **Thickness Slider**: Adjust the thickness of the pen and highlighter.
+- **Undo/Redo**: Step backward and forward through your annotations.
+- **Clear All**: Instantly remove all drawings from the screen.
+- **Screenshot**: Capture your screen with annotations and save it as a PNG file.
+- **Multi-Monitor Support**: The annotation window automatically appears on your active monitor.
+
+## Requirements
+
+- Windows 10 or Windows 11
+- .NET 6.0 SDK (or later)
+
+## How to Build
+
+1.  **Clone the repository** (or download the source code).
+2.  **Open a terminal** (like Command Prompt or PowerShell) and navigate to the `ScreenAnnotation` project directory.
+3.  **Run the build command**:
+    ```sh
+    dotnet build --configuration Release
+    ```
+4.  The compiled application will be located in the `bin/Release/net6.0-windows/` directory.
+
+## How to Run
+
+After building the application, you can run it directly from the output folder:
+
+```sh
+./bin/Release/net6.0-windows/ScreenAnnotation.exe
+```
+
+Alternatively, you can use the `dotnet run` command from the project directory:
+
+```sh
+dotnet run --project ScreenAnnotation.csproj
+```
+
+## How to Use
+
+1.  **Launch the application**. The annotation window will be hidden by default.
+2.  **Press `Ctrl+Alt+A`** to show the annotation overlay and the toolbar.
+3.  **Use the toolbar** to select your desired tool, color, and thickness.
+4.  **Draw on the screen**.
+5.  **Press `Ctrl+Alt+A`** again to hide the annotations and interact with the desktop underneath.
+6.  Use the **Screenshot** button to save your work or the **Exit** button to close the application.
+
+## Creating an Installer (MSIX)
+
+To package this application into an MSIX installer for easy distribution, you can add a "Windows Application Packaging Project" to the solution in Visual Studio.
+
+1.  Open the `ScreenAnnotation.csproj` in Visual Studio.
+2.  Right-click the solution in the Solution Explorer and go to **Add > New Project...**.
+3.  Search for and select the **Windows Application Packaging Project** template. Give it a name (e.g., `ScreenAnnotation.Package`).
+4.  In the new packaging project, right-click the **Dependencies** node (or Applications node) and select **Add Project Reference...**.
+5.  Check the `ScreenAnnotation` project and click **OK**.
+6.  Set the packaging project as the startup project.
+7.  To create the package, right-click the packaging project and select **Publish > Create App Packages...**. Follow the wizard to create the MSIX installer. You can choose to sign it with a temporary certificate for testing.
+
+This will produce an `.msix` file that can be installed on Windows 10/11 machines.

--- a/ScreenAnnotation/ScreenAnnotation.csproj
+++ b/ScreenAnnotation/ScreenAnnotation.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+
+</Project>

--- a/ScreenAnnotation/Toolbar.xaml
+++ b/ScreenAnnotation/Toolbar.xaml
@@ -1,0 +1,54 @@
+<UserControl x:Class="ScreenAnnotation.Toolbar"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:ScreenAnnotation"
+             mc:Ignorable="d"
+             d:DesignHeight="60" d:DesignWidth="800">
+    <Border Background="#A0000000" CornerRadius="10" Padding="5">
+        <StackPanel Orientation="Horizontal">
+            <StackPanel.Resources>
+                <Style TargetType="Button">
+                    <Setter Property="Background" Value="Transparent"/>
+                    <Setter Property="Foreground" Value="White"/>
+                    <Setter Property="BorderThickness" Value="0"/>
+                    <Setter Property="Padding" Value="10"/>
+                    <Setter Property="Margin" Value="2"/>
+                    <Setter Property="FontWeight" Value="Bold"/>
+                </Style>
+                <Style TargetType="Separator">
+                    <Setter Property="Background" Value="#50FFFFFF"/>
+                    <Setter Property="Margin" Value="5,0"/>
+                </Style>
+            </StackPanel.Resources>
+
+            <!-- Tool Buttons -->
+            <Button x:Name="PenButton" Content="Pen"/>
+            <Button x:Name="HighlighterButton" Content="Highlighter"/>
+            <Button x:Name="EraserButton" Content="Eraser"/>
+
+            <Separator/>
+
+            <!-- Color Palette -->
+            <Button x:Name="RedColorButton" Background="Red" Width="30" Height="30" Margin="2"/>
+            <Button x:Name="BlueColorButton" Background="Blue" Width="30" Height="30" Margin="2"/>
+            <Button x:Name="GreenColorButton" Background="Green" Width="30" Height="30" Margin="2"/>
+            <Button x:Name="BlackColorButton" Background="Black" Width="30" Height="30" Margin="2"/>
+
+            <Separator/>
+
+            <!-- Thickness Slider -->
+            <Slider x:Name="ThicknessSlider" Minimum="1" Maximum="20" Value="5" Width="150" VerticalAlignment="Center"/>
+
+            <Separator/>
+
+            <!-- Action Buttons -->
+            <Button x:Name="UndoButton" Content="Undo"/>
+            <Button x:Name="RedoButton" Content="Redo"/>
+            <Button x:Name="ClearButton" Content="Clear"/>
+            <Button x:Name="ScreenshotButton" Content="Screenshot"/>
+            <Button x:Name="ExitButton" Content="Exit"/>
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/ScreenAnnotation/Toolbar.xaml.cs
+++ b/ScreenAnnotation/Toolbar.xaml.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace ScreenAnnotation
+{
+    /// <summary>
+    /// Interaction logic for Toolbar.xaml
+    /// </summary>
+    public partial class Toolbar : UserControl
+    {
+        public event RoutedEventHandler PenButtonClick;
+        public event RoutedEventHandler HighlighterButtonClick;
+        public event RoutedEventHandler EraserButtonClick;
+        public event RoutedEventHandler UndoButtonClick;
+        public event RoutedEventHandler RedoButtonClick;
+        public event RoutedEventHandler ClearButtonClick;
+        public event RoutedEventHandler ScreenshotButtonClick;
+        public event RoutedEventHandler ExitButtonClick;
+        public event RoutedPropertyChangedEventHandler<double> ThicknessChanged;
+        public event RoutedEventHandler ColorButtonClick;
+
+        public Toolbar()
+        {
+            InitializeComponent();
+
+            PenButton.Click += (s, e) => PenButtonClick?.Invoke(this, e);
+            HighlighterButton.Click += (s, e) => HighlighterButtonClick?.Invoke(this, e);
+            EraserButton.Click += (s, e) => EraserButtonClick?.Invoke(this, e);
+            UndoButton.Click += (s, e) => UndoButtonClick?.Invoke(this, e);
+            RedoButton.Click += (s, e) => RedoButtonClick?.Invoke(this, e);
+            ClearButton.Click += (s, e) => ClearButtonClick?.Invoke(this, e);
+            ScreenshotButton.Click += (s, e) => ScreenshotButtonClick?.Invoke(this, e);
+            ExitButton.Click += (s, e) => ExitButtonClick?.Invoke(this, e);
+            ThicknessSlider.ValueChanged += (s, e) => ThicknessChanged?.Invoke(this, e);
+
+            RedColorButton.Click += ColorButton_Click;
+            BlueColorButton.Click += ColorButton_Click;
+            GreenColorButton.Click += ColorButton_Click;
+            BlackColorButton.Click += ColorButton_Click;
+        }
+
+        private void ColorButton_Click(object sender, RoutedEventArgs e)
+        {
+            ColorButtonClick?.Invoke(sender, e);
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces a new C# WPF application for desktop screen annotation.

The application provides a transparent overlay that allows users to draw on top of any open windows. It meets the core MVP requirements, including:

- A global hotkey (Ctrl+Alt+A) to toggle the annotation mode.
- Pen, highlighter, and eraser tools.
- Color and thickness selection.
- Undo, redo, and clear functionality.
- A screenshot feature to save the annotated screen as a PNG.
- Multi-monitor support, ensuring the window appears on the active display.

The project is structured with a main window, a reusable toolbar user control, and a helper class for Win32 hotkey registration. A detailed README file is included with instructions for building, running, and packaging the application.